### PR TITLE
Some typing simplifications

### DIFF
--- a/atomistics/calculators/ase.py
+++ b/atomistics/calculators/ase.py
@@ -7,7 +7,7 @@ from atomistics.calculators.wrapper import task_evaluation
 if TYPE_CHECKING:
     from ase import Atoms
     from ase.calculators.calculator import Calculator as ASECalculator
-    from atomistics.calculators.wrapper import TaskName
+    from atomistics.calculators.interface import TaskName
 
 
 @task_evaluation

--- a/atomistics/calculators/ase.py
+++ b/atomistics/calculators/ase.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from atomistics.calculators.wrapper import task_evaluation, TaskName
+from atomistics.calculators.wrapper import task_evaluation
 
 if TYPE_CHECKING:
     from ase import Atoms
     from ase.calculators.calculator import Calculator as ASECalculator
+    from atomistics.calculators.wrapper import TaskName
 
 
 @task_evaluation

--- a/atomistics/calculators/ase.py
+++ b/atomistics/calculators/ase.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from atomistics.calculators.wrapper import task_evaluation
+from atomistics.calculators.wrapper import task_evaluation, TaskName
 
 if TYPE_CHECKING:
     from ase import Atoms
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 @task_evaluation
 def evaluate_with_ase(
     structure: Atoms,
-    tasks: list[str],
+    tasks: list[TaskName],
     ase_calculator: ASECalculator
 ):
     structure.calc = ase_calculator

--- a/atomistics/calculators/interface.py
+++ b/atomistics/calculators/interface.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import NewType, Union, TYPE_CHECKING
+from typing import NewType, Union, Any, TYPE_CHECKING
 
 # best would be StrEnum from py3.11
 import sys
@@ -16,9 +16,13 @@ class TaskEnum(StrEnum):
     calc_forces = "calc_forces"
 
 if TYPE_CHECKING:
-    TaskName = NewType("TaskName", Union[str, TaskEnum])
-    TaskSpec = NewType("TaskSpec", tuple[Atoms, list[TaskName]])
-    TaskDict = NewType("TaskDict", dict[str, TaskSpec])
+    from ase import Atoms
 
-    TaskResults = NewType("TaskResults", dict[TaskName, Any])
-    ResultsDict = NewType("ResultsDict", dict[str, TaskResults])
+    TaskName = Union[str, TaskEnum]
+    TaskSpec = tuple[Atoms, list[TaskName]]
+    TaskDict = dict[str, TaskSpec]
+
+    TaskResults = dict[TaskName, Any]
+    ResultsDict = dict[str, TaskResults]
+
+    SimpleEvaluator = callable[[Atoms, list[TaskName], ...], TaskResults]

--- a/atomistics/calculators/interface.py
+++ b/atomistics/calculators/interface.py
@@ -15,12 +15,17 @@ class TaskEnum(StrEnum):
     calc_energy = "calc_energy"
     calc_forces = "calc_forces"
 
+class TaskOutputEnum(Enum):
+    energy = "calc_energy"
+    forces = "calc_forces"
+
 if TYPE_CHECKING:
     from ase import Atoms
 
     TaskName = Union[str, TaskEnum]
     TaskSpec = tuple[Atoms, list[TaskName]]
     TaskDict = dict[str, TaskSpec]
+
 
     TaskResults = dict[TaskName, Any]
     ResultsDict = dict[str, TaskResults]

--- a/atomistics/calculators/interface.py
+++ b/atomistics/calculators/interface.py
@@ -1,0 +1,24 @@
+from enum import Enum
+from typing import NewType, Union, TYPE_CHECKING
+
+# best would be StrEnum from py3.11
+import sys
+if sys.version_info.minor < 11:
+    # official impl' is not significantly different
+    class StrEnum(str, Enum):
+        def __str__(self):
+            return str(self.value)
+else:
+    from enum import StrEnum
+
+class TaskEnum(StrEnum):
+    calc_energy = "calc_energy"
+    calc_forces = "calc_forces"
+
+if TYPE_CHECKING:
+    TaskName = NewType("TaskName", Union[str, TaskEnum])
+    TaskSpec = NewType("TaskSpec", tuple[Atoms, list[TaskName]])
+    TaskDict = NewType("TaskDict", dict[str, TaskSpec])
+
+    TaskResults = NewType("TaskResults", dict[TaskName, Any])
+    ResultsDict = NewType("ResultsDict", dict[str, TaskResults])

--- a/atomistics/calculators/lammps.py
+++ b/atomistics/calculators/lammps.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from ase import Atoms
     from pandas import DataFrame
     from pylammpsmpi import LammpsASELibrary
-    from atomistics.calculators.wrapper import TaskName
+    from atomistics.calculators.interface import TaskName
 
 
 @task_evaluation

--- a/atomistics/calculators/lammps.py
+++ b/atomistics/calculators/lammps.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from pylammpsmpi import LammpsASELibrary
 
-from atomistics.calculators.wrapper import task_evaluation
+from atomistics.calculators.wrapper import task_evaluation, TaskName
 from atomistics.calculators.lammps_library.calculator import (
     _run_simulation,
     lammps_input_template as _lammps_input_template,
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 @task_evaluation
 def evaluate_with_lammps_library(
     structure: Atoms,
-    tasks: list[str],
+    tasks: list[TaskName],
     potential_dataframe: DataFrame,
     lmp: LammpsASELibrary,
 ):

--- a/atomistics/calculators/lammps.py
+++ b/atomistics/calculators/lammps.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from pylammpsmpi import LammpsASELibrary
 
-from atomistics.calculators.wrapper import task_evaluation, TaskName
+from atomistics.calculators.wrapper import task_evaluation
 from atomistics.calculators.lammps_library.calculator import (
     _run_simulation,
     lammps_input_template as _lammps_input_template,
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from ase import Atoms
     from pandas import DataFrame
     from pylammpsmpi import LammpsASELibrary
+    from atomistics.calculators.wrapper import TaskName
 
 
 @task_evaluation

--- a/atomistics/calculators/wrapper.py
+++ b/atomistics/calculators/wrapper.py
@@ -5,11 +5,17 @@ that evaluate a task dictionary.
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from enum import Enum, auto
+from typing import NewType, Union, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ase import Atoms
 
+class TaskEnum(Enum):
+    calc_energy = "calc_energy"
+    calc_forces = "calc_forces"
+
+TaskName = NewType("TaskName", Union[str, TaskEnum])
 
 def _convert_task_dict(
     old_task_dict: dict[str, dict[str, Atoms]]
@@ -31,7 +37,6 @@ def _convert_task_dict(
             except KeyError:
                 task_dict[label] = (structure, [method_name])
     return task_dict
-
 
 def task_evaluation(
     calculate: callable[[Atoms, list[str], ...], dict[str, Any]],

--- a/atomistics/calculators/wrapper.py
+++ b/atomistics/calculators/wrapper.py
@@ -16,7 +16,8 @@ if TYPE_CHECKING:
             TaskSpec,
             TaskDict,
             TaskResults,
-            ResultsDict
+            ResultsDict,
+            SimpleEvaluator
     )
 
 
@@ -42,7 +43,7 @@ def _convert_task_dict(
     return task_dict
 
 def task_evaluation(
-    calculate: callable[[Atoms, list[TaskName], ...], TaskResults],
+    calculate: SimpleEvaluator,
 ) -> callable[[dict[TaskName, dict[str, Atoms]], ...], ResultsDict]:
     """
     Takes a callable that acts on a single structure and a (string) list of tasks to

--- a/atomistics/calculators/wrapper.py
+++ b/atomistics/calculators/wrapper.py
@@ -18,8 +18,8 @@ class TaskEnum(Enum):
 TaskName = NewType("TaskName", Union[str, TaskEnum])
 
 def _convert_task_dict(
-    old_task_dict: dict[str, dict[str, Atoms]]
-) -> dict[str, tuple[Atoms, list[str]]]:
+    old_task_dict: dict[TaskName, dict[str, Atoms]]
+) -> dict[str, tuple[Atoms, list[TaskName]]]:
     """
     Converts the existing task dictionaries of the format
     `{result_type_string: {structure_label_string: structure, ...}, ...}`
@@ -39,8 +39,8 @@ def _convert_task_dict(
     return task_dict
 
 def task_evaluation(
-    calculate: callable[[Atoms, list[str], ...], dict[str, Any]],
-) -> callable[[dict[str, dict[str, Atoms]], ...], dict[str, dict[str, Any]]]:
+    calculate: callable[[Atoms, list[TaskName], ...], dict[TaskName, Any]],
+) -> callable[[dict[TaskName, dict[str, Atoms]], ...], dict[str, dict[TaskName, Any]]]:
     """
     Takes a callable that acts on a single structure and a (string) list of tasks to
     and maps it to a function that operates on a task-list dictionary of structures,
@@ -56,11 +56,11 @@ def task_evaluation(
         callable: The function operating on a different space.
     """
     def evaluate_with_calculator(
-        task_dict: dict[str, dict[str, Atoms]],
+        task_dict: dict[TaskName, dict[str, Atoms]],
         # TODO: Make workflows pass task dicts: dict[str, tuple[Atoms, list[str]]],
         *calculate_args,
         **calculate_kwargs,
-    ) -> dict[str, dict[str, Any]]:
+    ) -> dict[str, dict[TaskName, Any]]:
         task_dict = _convert_task_dict(task_dict)
         results_dict = {}
         for label, (structure, tasks) in task_dict.items():

--- a/atomistics/calculators/wrapper.py
+++ b/atomistics/calculators/wrapper.py
@@ -5,32 +5,20 @@ that evaluate a task dictionary.
 
 from __future__ import annotations
 
-from enum import Enum, auto
 from typing import NewType, Union, Any, TYPE_CHECKING
 
-# best would be StrEnum from py3.11
-import sys
-if sys.version_info.minor < 11:
-    # official impl' is not significantly different
-    class StrEnum(str, Enum):
-        def __str__(self):
-            return str(self.value)
-else:
-    from enum import StrEnum
-
-class TaskEnum(StrEnum):
-    calc_energy = "calc_energy"
-    calc_forces = "calc_forces"
+from atomistics.calculators.interface import TaskEnum
 
 if TYPE_CHECKING:
     from ase import Atoms
+    from atomistics.calculators.interface import (
+            TaskName,
+            TaskSpec,
+            TaskDict,
+            TaskResults,
+            ResultsDict
+    )
 
-    TaskName = NewType("TaskName", Union[str, TaskEnum])
-    TaskSpec = NewType("TaskSpec", tuple[Atoms, list[TaskName]])
-    TaskDict = NewType("TaskDict", dict[str, TaskSpec])
-
-    TaskResults = NewType("TaskResults", dict[TaskName, Any])
-    ResultsDict = NewType("ResultsDict", dict[str, TaskResults])
 
 def _convert_task_dict(
     old_task_dict: dict[TaskName, dict[str, Atoms]]

--- a/atomistics/calculators/wrapper.py
+++ b/atomistics/calculators/wrapper.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import NewType, Union, Any, TYPE_CHECKING
 
-from atomistics.calculators.interface import TaskEnum
+from atomistics.calculators.interface import TaskEnum, TaskOutputEnum
 
 if TYPE_CHECKING:
     from ase import Atoms
@@ -71,7 +71,7 @@ def task_evaluation(
             tasks = [TaskEnum(t) for t in tasks]
             output = calculate(structure, tasks, *calculate_args, **calculate_kwargs)
             for task_name in tasks:
-                result_name = task_name.lstrip("calc_")
+                result_name = TaskOutputEnum(task_name).name
                 try:
                     results_dict[result_name][label] = output[result_name]
                 except KeyError:


### PR DESCRIPTION
I've added enums and derived type definitions to make the whole code a bit more readable.  This changes nothing about the behavior, but it allows for automatic range checking of the 'task names' `calc_energy` and `calc_forces` and defines a single point where the expected interface for user/dev is defined.  I think this will be very beneficial if we allow additional "tasks" in the future.